### PR TITLE
DocumentReference, comprehensive: add min 1 for context and sourcePatientInfo

### DIFF
--- a/input/fsh/documentReference.fsh
+++ b/input/fsh/documentReference.fsh
@@ -65,8 +65,10 @@ Description:    "A profile on the DocumentReference resource for MHD with Compre
 * content.attachment.language 1..1
 * content.attachment.creation 1..1
 * content.format 1..1
+* context 1..1
 * context.facilityType 1..1
 * context.practiceSetting 1..1
+* context.sourcePatientInfo 1..1 
 
 // equivalent to MHD Comprehensive DocumentReference - contained
 Profile:        ComprehensiveDocumentReference

--- a/input/fsh/ex-DocumentReference.fsh
+++ b/input/fsh/ex-DocumentReference.fsh
@@ -34,6 +34,7 @@ Description: "Example of a Comprehensive DocumentReference resource. This is min
 * context.facilityType = http://snomed.info/sct#82242000
 * context.practiceSetting =  http://snomed.info/sct#408467006
 * content.format = http://ihe.net/fhir/ValueSet/IHE.FormatCode.codesystem#urn:ihe:iti:xds-sd:text:2008
+* context.sourcePatientInfo = Reference(Patient/ex-patient)
 
 Instance:   ex-DocumentReferenceUnContainedFully
 InstanceOf: IHE.MHD.UnContained.Comprehensive.DocumentReference


### PR DESCRIPTION
For XDS DocumentEntry sourcePatientId is R [Table 4.3.1-3: Sending Actor Metadata Attribute Optionality , XDS _DR](https://profiles.ihe.net/ITI/TF/Volume3/ch-4.3.html#4.3), this implicates for DocumentReference with the Comprehensive option also needs context.sourcePatientInfo (which maps to XDS sourcePatientId or sourcePatientInfo) as required. Since context itself is 0..1 this should be also changed to 1..1, otherwise sourcePatientInfo min requirement will not be enforced.