### PR TITLE
Slicing evaluation for minimalProvideDocumentBundle

### DIFF
--- a/input/fsh/provideBundle.fsh
+++ b/input/fsh/provideBundle.fsh
@@ -43,7 +43,8 @@ Description:    "A profile on the Bundle transaction for Provide Document resour
 * entry[DocumentRefs] ^definition = "any and all DocumentReference that are part of the SubmissionSet. These might be new, replacements, or other associations"
 * entry[DocumentRefs].request 1..1
 * entry[DocumentRefs].request.method = #POST
-* entry[Documents].resource only http://hl7.org/fhir/StructureDefinition/Binary
+* entry[Documents].resource ^type.code = "Binary"
+* entry[Documents].resource ^type.profile = Canonical(Binary)
 * entry[Documents] ^short = "the documents"
 * entry[Documents] ^definition = "the documents referenced by the DocumentReference resources"
 * entry[Documents].request 1..1
@@ -55,7 +56,8 @@ Description:    "A profile on the Bundle transaction for Provide Document resour
 * entry[Folders] ^definition = "any Folders being created or updated"
 * entry[Folders].request 1..1
 * entry[Folders].request.method = #POST
-* entry[Patient].resource only http://hl7.org/fhir/StructureDefinition/Patient
+* entry[Patient].resource ^type.code = "Patient"
+* entry[Patient].resource ^type.profile = Canonical(Patient)
 * entry[Patient] ^short = "the Patient"
 * entry[Patient] ^definition = "the Patient"
 


### PR DESCRIPTION
https://profiles.ihe.net/ITI/MHD/4.0.0-comment/qa.html#C__Users_john.moehrke_Git_ITI.MHD_fsh-generated_resources_Bundle-ex-minimalProvideDocumentBundle

shows errors in qa:

Bundle/ex-minimalProvideDocumentBundle: Bundle.entry[0] (l17/c6) | error | Slicing cannot be evaluated: Profile based discriminators must have a type with a profile (Bundle.entry:Documents.resource in profile http://profiles.ihe.net/ITI/MHD/StructureDefinition/IHE.MHD.Minimal.ProvideBundle)
-- | -- | --
Bundle/ex-minimalProvideDocumentBundle: Bundle.entry[1] (l36/c6) | error | Slicing cannot be evaluated: Profile based discriminators must have a type with a profile (Bundle.entry:Documents.resource in profile http://profiles.ihe.net/ITI/MHD/StructureDefinition/IHE.MHD.Minimal.ProvideBundle)

this is due to that sushi does not fill the in the profile which is needed by the ig publisher. see similar discussion on [zulip](https://chat.fhir.org/#narrow/stream/215610-shorthand/topic/Support.20for.20slicing.20with.20type.20code.20'Resource'.20and.20profile.20.3F)

PR adjusts slicing type.code and type.profile that the errors disappear (there are still some errors in the example). 
