### PR TITLE
MHD: Provide Document Bundle - clarify replaceTo behaviour with transaction

### DIFF
--- a/input/fsh/documentReference.fsh
+++ b/input/fsh/documentReference.fsh
@@ -1,3 +1,10 @@
+Profile:        PatchParameters
+Parent:         Parameters
+Id:             IHE.MHD.Patch.Parameters
+Title:          "MHD DocumentReference Pactch Parameters"
+Description:    "A profile on the Parameters resource to update DocumentReference" 
+* parameter.name = "operation"
+
 // equivalent to MHD Minimal DocumentReference
 Profile:        MinimalDocumentReference
 Parent:         DocumentReference
@@ -44,6 +51,12 @@ Description:    "A profile on the DocumentReference resource for MHD with minima
 * context.practiceSetting 0..1 MS
 * context.sourcePatientInfo 0..1 MS
 * context.related 0..*
+* obeys iti-mhd-repl
+
+Invariant:   iti-mhd-repl
+Description: "a DocumetReference replacements needs to relate to a superseded DocumentReference"
+Expression:  "relatesTo.empty() or (relatesTo.code='replaces' implies relatesTo.target.exists())"
+Severity:    #error
 
 // equivalent to MHD DocumentReference Comprehensive UnContained Option
 Profile:        UnContainedComprehensiveDocumentReference

--- a/input/fsh/ex-ProvideBundles3.fsh
+++ b/input/fsh/ex-ProvideBundles3.fsh
@@ -138,3 +138,118 @@ Usage: #inline
 * contentType = #text/plain
 * data = "SGVsbG8gV29ybGQ="
 
+
+Instance: aaaaaaaa-bbbb-cccc-eeee-e00333300003
+InstanceOf: Binary
+Title: "Dummy Binary document that says: Thanks for all the fish"
+Description: """
+For Bundling Example binary that 
+- holds \"Thanks for all the fish\"
+- hash e8e3172143001587cb7508446aa092eb51995809
+- base64 of ZThlMzE3MjE0MzAwMTU4N2NiNzUwODQ0NmFhMDkyZWI1MTk5NTgwOQ==
+- size 24
+"""
+Usage: #inline
+* meta.security = http://terminology.hl7.org/CodeSystem/v3-ActReason#HTEST
+* contentType = #text/plain
+* data = "VGhhbmtzIGZvciBhbGwgdGhlIGZpc2g="
+
+
+Instance:   aaaaaaaa-bbbb-cccc-ffff-e00333300002
+InstanceOf: Parameters
+Title:      "DocumentReference for Comprehensive metadata beeing replaced"
+Description: "Example of a comprehensive DocumentReference resource beeing replaced"
+Usage: #inline
+* parameter.name = "operation"
+* parameter.part[0].name = "type"
+* parameter.part[=].valueCode = #replace
+* parameter.part[+].name = "path"
+* parameter.part[=].valueString = "DocumentReference.status"
+* parameter.part[+].name = "value"
+* parameter.part[=].valueCode = #superseded
+
+Instance:   aaaaaaaa-bbbb-cccc-eeee-e00333300001
+InstanceOf: IHE.MHD.Comprehensive.SubmissionSet
+Title:      "SubmissionSet for Comprehensive metadata in a bundle with a replace"
+Description: "Example of a comprehensive submissionSet in List resource with an intended recipient used in a bundle."
+Usage: #inline
+* text.status = #extensions
+* text.div = "<div xmlns=\"http://www.w3.org/1999/xhtml\">SubmissionSet with Patient</div>"
+* meta.security = http://terminology.hl7.org/CodeSystem/v3-ActReason#HTEST
+* identifier[+].system = "urn:ietf:rfc:3986"
+* identifier[=].value = "urn:oid:1.2.129.6.58.92.88337.1"
+* identifier[=].use = #official
+* identifier[+].system = "http://example.org/documents"
+* identifier[=].value = "23425234-23470-1"
+* identifier[=].use = #usual
+* status = #current
+* mode = #working
+* code = MHDlistTypes#submissionset
+* date = 2020-02-02T23:50:50-05:00
+* entry[+].item = Reference(urn:uuid:aaaaaaaa-bbbb-cccc-eeee-e00333300002)
+* extension[sourceId].valueIdentifier.value = "urn:oid:1.2.3.4"
+* subject = Reference(Patient/ex-patient)
+* extension[designationType].valueCodeableConcept = http://snomed.info/sct#225728007
+
+
+Instance:   ex-comprehensiveProvideDocumentBundleReplace
+InstanceOf: IHE.MHD.Comprehensive.ProvideBundle
+Title:      "Provide Document Bundle with Comprehensive metadata of one document which replaces another document"
+Description: "Example of a comprehensive Provide Document Bundle for a publication which replaces another document.
+- The bundle contains
+  - SubmissionSet - identifies one documentReference
+  - DocumentReference - Two DocumentReferences, an update to the old DocumentReference and the new DocumentReferences relates to the old DocumentReference
+  - Binary - the document
+  - the Patient is contained in the DocumentReference
+  - the Patient is also a reference to a PIXm/PDQm retrieved Resource."
+Usage: #example
+* meta.security = http://terminology.hl7.org/CodeSystem/v3-ActReason#HTEST
+* type = #transaction
+* timestamp = 2020-02-02T23:50:50-05:00
+* entry[SubmissionSet].fullUrl = "urn:uuid:aaaaaaaa-bbbb-cccc-eeee-e00333300001"
+* entry[SubmissionSet].resource = aaaaaaaa-bbbb-cccc-eeee-e00333300001
+* entry[SubmissionSet].request.url = "List"
+* entry[SubmissionSet].request.method = #POST
+* entry[UpdateDocumentRefs].fullUrl = "urn:uuid:aaaaaaaa-bbbb-cccc-ffff-e00333300002"
+* entry[UpdateDocumentRefs].resource = aaaaaaaa-bbbb-cccc-ffff-e00333300002
+* entry[UpdateDocumentRefs].request.url = "DocumentReference/ex-documentreference"
+* entry[UpdateDocumentRefs].request.method = #PATCH
+* entry[DocumentRefs].fullUrl = "urn:uuid:aaaaaaaa-bbbb-cccc-eeee-e00333300002"
+* entry[DocumentRefs].resource = aaaaaaaa-bbbb-cccc-eeee-e00333300002
+* entry[DocumentRefs].request.url = "DocumentReference"
+* entry[DocumentRefs].request.method = #POST
+* entry[Documents].fullUrl = "urn:uuid:aaaaaaaa-bbbb-cccc-eeee-e00333300003"
+* entry[Documents].resource = aaaaaaaa-bbbb-cccc-eeee-e00333300003
+* entry[Documents].request.url = "Binary"
+* entry[Documents].request.method = #POST
+
+Instance:   aaaaaaaa-bbbb-cccc-eeee-e00333300002
+InstanceOf: IHE.MHD.Comprehensive.DocumentReference
+Title:      "DocumentReference for Comprehensive metadata"
+Description: "Example of a comprehensive DocumentReference resource being used in a PUSH. This contains the Patient, thus equivilant of XDR/XDM use of sourcePatientInfo."
+Usage: #inline
+* meta.security = http://terminology.hl7.org/CodeSystem/v3-ActReason#HTEST
+* masterIdentifier.system = "urn:ietf:rfc:3986"
+* masterIdentifier.value = "urn:oid:1.2.840.113556.1.8000.2554.53432.348.12973.17740.34205.4355.50220.62012"
+* identifier.system = "urn:ietf:rfc:3986"
+* identifier.value = "urn:uuid:7d5bb8ac-68ee-4926-85e7-b8aac8e1f09d"
+* status = #current
+* contained[+] = aaaaaaaa-bbbb-cccc-dddd-e00333300004
+* context.sourcePatientInfo = Reference(aaaaaaaa-bbbb-cccc-dddd-e00333300004)
+* subject = Reference(Patient/ex-patient)
+* content.format = http://ihe.net/fhir/ihe.formatcode.fhir/CodeSystem/formatcode#urn:ihe:iti:xds-sd:text:2008
+* content.attachment.url = "urn:uuid:aaaaaaaa-bbbb-cccc-eeee-e00333300003"
+* content.attachment.contentType = #text/plain
+* content.attachment.hash = "ZThlMzE3MjE0MzAwMTU4N2NiNzUwODQ0NmFhMDkyZWI1MTk5NTgwOQ=="
+* content.attachment.size = 24
+* type = http://loinc.org#60591-5
+* category = http://loinc.org#11369-6
+* securityLabel = http://terminology.hl7.org/CodeSystem/v3-Confidentiality#R
+* context.facilityType = http://snomed.info/sct#82242000
+* context.practiceSetting =  http://snomed.info/sct#408467006
+* content.attachment.language = urn:ietf:bcp:47#en
+* content.attachment.creation = 2020-02-02T23:50:50-05:00
+* content.attachment.title = "Thanks for all the fish"
+* date = 2020-02-02T23:50:50-05:00
+* relatesTo.code = #replaces
+* relatesTo.target = Reference(DocumentReference/ex-documentreference)

--- a/input/fsh/provideBundle.fsh
+++ b/input/fsh/provideBundle.fsh
@@ -15,14 +15,17 @@ Description:    "A profile on the Bundle transaction for ITI-65 Provide Document
   - may create/update/read one [Patient](http://hl7.org/fhir/R4/patient.html)"
 * meta.profile 1..*
 * type = #transaction
-* entry ^slicing.discriminator.type = #profile
-* entry ^slicing.discriminator.path = "resource"
+* entry ^slicing.discriminator[0].type = #profile
+* entry ^slicing.discriminator[0].path = "resource"
+* entry ^slicing.discriminator[1].type = #value
+* entry ^slicing.discriminator[1].path = "request.method"
 * entry ^slicing.rules = #closed
 * entry ^slicing.description = "Slicing based on the profile conformance of the entry"
 * entry and entry.resource MS
 * entry contains 
     SubmissionSet 1..1 and
     DocumentRefs 0..* and
+    UpdateDocumentRefs 0..* and
     Documents 0..* and
     Folders 0..* and
     Patient 0..1
@@ -36,10 +39,17 @@ Description:    "A profile on the Bundle transaction for ITI-65 Provide Document
 * entry[DocumentRefs].resource only 
     IHE.MHD.Minimal.DocumentReference 
 * entry[DocumentRefs] ^short = "the DocumentReference resources"
-* entry[DocumentRefs] ^definition = "any and all DocumentReference that are part of the SubmissionSet. These might be new, replacements, or other associations"
+* entry[DocumentRefs] ^definition = "any new DocumentReference that are part of the SubmissionSet. These might be new or other associations"
 * entry[DocumentRefs].resource 1..1
 * entry[DocumentRefs].request 1..1
 * entry[DocumentRefs].request.method = #POST
+* entry[UpdateDocumentRefs].resource only 
+    IHE.MHD.Patch.Parameters 
+* entry[UpdateDocumentRefs] ^short = "the superseded DocumentReference resources"
+* entry[UpdateDocumentRefs] ^definition = "any updated DocumentReference that are part of the SubmissionSet if a new new DocumentReference replaces this DocumentReference."
+* entry[UpdateDocumentRefs].resource 1..1
+* entry[UpdateDocumentRefs].request 1..1
+* entry[UpdateDocumentRefs].request.method = #PATCH
 * entry[Documents].resource ^type.code = "Binary"
 * entry[Documents].resource ^type.profile = Canonical(Binary)
 * entry[Documents] ^short = "the documents"

--- a/input/pagecontent/ITI-65.md
+++ b/input/pagecontent/ITI-65.md
@@ -102,7 +102,7 @@ When the [UnContained Reference Option](1332_actor_options.html#13323-uncontaine
 
 ###### 2:3.65.4.1.2.3 Replace, Transform, Signs, and Append Associations
 
-The DocumentReference.relatesTo element indicates an association between DocumentReference resources. The relatesTo.target element in the provided DocumentReference points at the pre-existing DocumentReference that is being replaced, transformed, signed, or appended. The relatesTo.code element in the provided DocumentReference shall be the appropriate relationship type code defined in [http://hl7.org/fhir/R4/valueset-document-relationship-type.html](http://hl7.org/fhir/R4/valueset-document-relationship-type.html). 
+The DocumentReference.relatesTo element indicates an association between DocumentReference resources. The relatesTo.target element in the provided DocumentReference points at the pre-existing DocumentReference that is being replaced, transformed, signed, or appended. The relatesTo.code element in the provided DocumentReference shall be the appropriate relationship type code defined in [http://hl7.org/fhir/R4/valueset-document-relationship-type.html](http://hl7.org/fhir/R4/valueset-document-relationship-type.html). If a DocumentReference will be replaced, the to be replaced DocumentReference needs to be added and updated to status 'superseded' within the transaction bundle.
 
 ##### 2:3.65.4.1.3 Expected Actions
 


### PR DESCRIPTION
This PR illustrates how the replaceTo behaviour could be add to the ITI-65 Provide Document Bundle. An example has been added and the profiles have been adjusted that the to be replaced DocumentReference can be added to the transaction (the status needs to be updated to superseded for MHD). That this update of the DocumentReference is been enforced a FHIR constraint has been added that check that for a replace relatesTo a superseded DocumentReference is provided. See Issue https://github.com/IHE/ITI.MHD/issues/100 for additional discussion