### PR TITLE
Profiling of Bundle with PATCH #222

### DIFF
--- a/input/fsh/documentReference.fsh
+++ b/input/fsh/documentReference.fsh
@@ -2,7 +2,7 @@ Profile:        PatchParameters
 Parent:         Parameters
 Id:             IHE.MHD.Patch.Parameters
 Title:          "MHD DocumentReference Patch Parameters"
-Description:    "A profile on the Parameters resource to update DocumentReference" 
+Description:    "A profile on the Parameters resource to update the superseded DocumentReference status." 
 * parameter ^slicing.discriminator.type = #value
 * parameter ^slicing.discriminator.path = "name"
 * parameter ^slicing.rules = #open

--- a/input/fsh/documentReference.fsh
+++ b/input/fsh/documentReference.fsh
@@ -3,7 +3,21 @@ Parent:         Parameters
 Id:             IHE.MHD.Patch.Parameters
 Title:          "MHD DocumentReference Patch Parameters"
 Description:    "A profile on the Parameters resource to update DocumentReference" 
-* parameter.name = "operation"
+* parameter ^slicing.discriminator.type = #value
+* parameter ^slicing.discriminator.path = "name"
+* parameter ^slicing.rules = #open
+* parameter contains operation 1..1
+* parameter[operation].name = "operation"
+* parameter[operation].part ^slicing.discriminator.type = #value
+* parameter[operation].part ^slicing.discriminator.path = "name"
+* parameter[operation].part ^slicing.rules = #open
+* parameter[operation].part contains path 1..1 and type 1..1 and value 1..1
+* parameter[operation].part[type].name = "type"
+* parameter[operation].part[type].valueCode = #replace
+* parameter[operation].part[path].name = "path"
+* parameter[operation].part[path].valueString = "DocumentReference.status"
+* parameter[operation].part[value].name = "value"
+* parameter[operation].part[value].valueCode = #superseded
 
 // equivalent to MHD Minimal DocumentReference
 Profile:        MinimalDocumentReference

--- a/input/fsh/provideBundle.fsh
+++ b/input/fsh/provideBundle.fsh
@@ -12,6 +12,7 @@ Description:    "A profile on the Bundle transaction for ITI-65 Provide Document
   - may create one or more [DocumentReference](StructureDefinition-IHE.MHD.Minimal.DocumentReference.html) that is either minimal, comprehensive, or unContained
     - with a document as a [Binary](http://hl7.org/fhir/R4/binary.html)
     - or, when implementing the **ITI-65 FHIR Document Publish** option, a [FHIR Document Bundle](http://hl7.org/fhir/R4/bundle.html)
+  - when DocumentReference replace is used the UpdateDocumentRefs slice is used to indicate the superseded DocumentReference
   - may create/update one or more [Folder type List](StructureDefinition-IHE.MHD.Minimal.Folder.html) that is either minimal, comprehensive, or unContained
   - may create/update/read one [Patient](http://hl7.org/fhir/R4/patient.html)"
 * meta.profile 1..*

--- a/input/pagecontent/ITI-65.md
+++ b/input/pagecontent/ITI-65.md
@@ -59,6 +59,7 @@ The FHIR Bundle.meta.profile shall have the following value depending on the act
   - may create one or more [DocumentReference](StructureDefinition-IHE.MHD.Minimal.DocumentReference.html) that is either minimal, comprehensive, or unContained
     - with a document as a [Binary](http://hl7.org/fhir/R4/binary.html)
     - or, when implementing the **ITI-65 FHIR Document Publish** option, a [FHIR Document Bundle](http://hl7.org/fhir/R4/bundle.html)
+  - when DocumentReference replace is used the UpdateDocumentRefs slice is used to indicate the superseded DocumentReference
   - may create/update one or more [Folder type List](StructureDefinition-IHE.MHD.Minimal.Folder.html) that is either minimal, comprehensive, or unContained
   - may create/update/read one [Patient](http://hl7.org/fhir/R4/patient.html)
 - [Comprehensive Metadata](StructureDefinition-IHE.MHD.Comprehensive.ProvideBundle.html): `https://profiles.ihe.net/ITI/MHD/StructureDefinition/IHE.MHD.Comprehensive.ProvideBundle`
@@ -69,6 +70,7 @@ The FHIR Bundle.meta.profile shall have the following value depending on the act
   - may create one or more [DocumentReference](StructureDefinition-IHE.MHD.Comprehensive.DocumentReference.html) that is comprehensive
     - with a document as a [Binary](http://hl7.org/fhir/R4/binary.html)
     - or, when implementing the **ITI-65 FHIR Document Publish** Option, a [FHIR Document Bundle](http://hl7.org/fhir/R4/bundle.html)
+  - when DocumentReference replace is used the UpdateDocumentRefs slice is used to indicate the superseded DocumentReference
   - may create/update one or more [Folder type List](StructureDefinition-IHE.MHD.Comprehensive.Folder.html) that is comprehensive
   - may create/update/read one [Patient](http://hl7.org/fhir/R4/patient.html)
 - [UnContained Comprehensive Metadata](StructureDefinition-IHE.MHD.UnContained.Comprehensive.ProvideBundle.html): `https://profiles.ihe.net/ITI/MHD/StructureDefinition/IHE.MHD.UnContained.Comprehensive.ProvideBundle` 
@@ -80,6 +82,7 @@ The FHIR Bundle.meta.profile shall have the following value depending on the act
   - may create one or more [DocumentReference](StructureDefinition-IHE.MHD.UnContained.Comprehensive.DocumentReference.html) that is comprehensive or unContained
     - with a document as a [Binary](http://hl7.org/fhir/R4/binary.html)
     - or, when implementing the **ITI-65 FHIR Document Publish** Option, a [FHIR Document Bundle](http://hl7.org/fhir/R4/bundle.html)
+  - when DocumentReference replace is used the UpdateDocumentRefs slice is used to indicate the superseded DocumentReference
   - may create/update one or more [Folder type List](StructureDefinition-IHE.MHD.Comprehensive.Folder.html) that is comprehensive
   - may create/update/read one [Patient](http://hl7.org/fhir/R4/patient.html)
 
@@ -112,7 +115,9 @@ When the [UnContained Reference Option](1332_actor_options.html#13323-uncontaine
 
 ###### 2:3.65.4.1.2.3 Replace, Transform, Signs, and Append Associations
 
-The DocumentReference.relatesTo element indicates an association between DocumentReference resources. The relatesTo.target element in the provided DocumentReference points at the pre-existing DocumentReference that is being replaced, transformed, signed, or appended. The relatesTo.code element in the provided DocumentReference shall be the appropriate relationship type code defined in [http://hl7.org/fhir/R4/valueset-document-relationship-type.html](http://hl7.org/fhir/R4/valueset-document-relationship-type.html). If a DocumentReference will be replaced, the to be replaced DocumentReference needs to be added and updated to status `superseded` within the transaction bundle (see [Example Bundle: Provide Document Bundle with Comprehensive metadata of one document which replaces another document](Bundle-ex-comprehensiveProvideDocumentBundleReplace.html) entry 2).
+The DocumentReference.relatesTo element indicates an association between DocumentReference resources. The relatesTo.target element in the provided DocumentReference points at the pre-existing DocumentReference that is being replaced, transformed, signed, or appended. The relatesTo.code element in the provided DocumentReference shall be the appropriate relationship type code defined in [http://hl7.org/fhir/R4/valueset-document-relationship-type.html](http://hl7.org/fhir/R4/valueset-document-relationship-type.html). 
+
+If a DocumentReference will be replaced, the to be replaced DocumentReference needs to be added and updated to status `superseded` within the transaction bundle with the [UpdateDocumentsRef slice](StructureDefinition-IHE.MHD.Minimal.ProvideBundle.html) (see [Example Bundle: Provide Document Bundle with Comprehensive metadata of one document which replaces another document](Bundle-ex-comprehensiveProvideDocumentBundleReplace.html) entry 2).
 
 ##### 2:3.65.4.1.3 Expected Actions
 


### PR DESCRIPTION
See #222 

* parameter.name = "operation" has generated a condition which applies to all Parameters, in that case also to the part parameter

to fix this:
1. convert it to a slicing that it applies only to the toplevel name
2. added subslice for the part.name, because it is know for the usecase what needs to be provided 

the 2nd step is optional (from line 14 on), the error disappears alos with just slicing to line 13

