### PR TITLE
Provide attributes for storing values relevant for XDS Metadata Update

### DIFF
--- a/input/fsh/documentReference.fsh
+++ b/input/fsh/documentReference.fsh
@@ -19,6 +19,40 @@ Description:    "A profile on the Parameters resource to update the superseded D
 * parameter[operation].part[value].name = "value"
 * parameter[operation].part[value].valueCode = #superseded
 
+
+Extension: RepositoryUniqueId
+Id: ihe-repositoryUniqueId
+Title: "XDS Document Repository ID"
+Description: "ID of XDS Document Repository where the document's binary contents are stored"
+* ^context[+].type = #element
+* ^context[=].expression = "DocumentReference"
+* value[x] only Identifier
+* valueIdentifier 1..1
+* valueIdentifier.system 1..1
+* valueIdentifier.system = "urn:ietf:rfc:3986"
+* valueIdentifier.id obeys mhd-startswithoid
+
+Extension: Version
+Id: ihe-version 
+Title: "Version of the Document Entry"
+Description: "holds the current version of the Document Entry"
+* ^context[+].type = #element
+* ^context[=].expression = "DocumentReference"
+* value[x] only positiveInt
+* valuePositiveInt 1..1
+
+Extension: DocumentAvailability
+Id: ihe-documentAvailability
+Title: "Status of the document in the XDS Document Repository"
+Description: "holds the status of the document in the XDS Document Repository"
+* ^context[+].type = #element
+* ^context[=].expression = "DocumentReference"
+* value[x] only Coding
+* valueCoding 1..1
+* valueCoding.system 1..1
+* valueCoding.system = "urn:ietf:rfc:3986"
+
+
 // equivalent to MHD Minimal DocumentReference
 Profile:        MinimalDocumentReference
 Parent:         DocumentReference
@@ -31,14 +65,22 @@ Description:    "A profile on the DocumentReference resource for MHD with minima
 - ebRIM implementation at [3:4.2.3.2 Document Entry](https://profiles.ihe.net/ITI/TF/Volume3/ch-4.2.html#4.2.3.2).
 - with use-cases and constraints found in [3:4.3 Additional Document Sharing Requirements](https://profiles.ihe.net/ITI/TF/Volume3/ch-4.3.html#4.3)"
 * modifierExtension 0..0
+* extension ^slicing.discriminator.type = #value
+* extension ^slicing.discriminator.path = "url"
+* extension ^slicing.rules = #open
+* extension contains
+    RepositoryUniqueId named repositoryUniqueId 0..1 and
+    Version named version 0..1 and
+    DocumentAvailability named documentAvailability 0..1
 * masterIdentifier only UniqueIdIdentifier
 * masterIdentifier 1..1
 * identifier 0..* MS
-* identifier ^slicing.discriminator.type = #value
-* identifier ^slicing.discriminator.path = "use"
+* identifier ^slicing.discriminator.type = #profile
+* identifier ^slicing.discriminator.path = "$this"
 * identifier ^slicing.rules = #open
-* identifier contains entryUUID 0..*
+* identifier contains entryUUID 0..* and logicalID 0..*
 * identifier[entryUUID] only EntryUUIDIdentifier
+* identifier[logicalID] only LogicalIDIdentifier
 * status 1..1
 * status from DocumentReferenceStats (required)
 * docStatus 0..0
@@ -124,7 +166,8 @@ Title: "XDS and MHD Mapping"
 * description -> "DocumentEntry.comments"
 * securityLabel -> "DocumentEntry.confidentialityCode"
 * content.attachment.creation -> "DocumentEntry.creationTime"
-* identifier -> "DocumentEntry.entryUUID"
+* identifier[entryUUID] -> "DocumentEntry.entryUUID"
+* identifier[logicalID] -> "DocumentEntry.logicalID"
 * context.event -> "DocumentEntry.eventCodeList"
 * content.format -> "DocumentEntry.formatCode"
 * content.attachment.hash -> "DocumentEntry.hash"
@@ -152,6 +195,9 @@ Title: "XDS and MHD Mapping"
 * relatesTo -> "DocumentEntry Associations"
 * relatesTo.code -> "DocumentEntry Associations.type"
 * relatesTo.target -> "DocumentEntry Associations.reference"
+* extension[repositoryUniqueId] -> "DocumentEntry.repositoryUniqueId"
+* extension[version] -> "DocumentEntry.version"
+* extension[documentAvailability] -> "DocumentEntry.documentAvailability"
 
 
 Instance:   AssociationTypeVsRelatesTo

--- a/input/fsh/ex-DocumentReference.fsh
+++ b/input/fsh/ex-DocumentReference.fsh
@@ -111,6 +111,9 @@ Usage: #example
 * identifier[entryUUID].system = "urn:ietf:rfc:3986"
 * identifier[entryUUID].value = "urn:uuid:0c287d32-01e3-4d87-9953-9fcc9404eb21"
 * identifier[entryUUID].use = #official
+* identifier[logicalID].system = "urn:ietf:rfc:3986"
+* identifier[logicalID].value = "urn:uuid:4f24b606-be7f-44b7-bc06-803d77925146"
+* identifier[logicalID].type.coding.code = MHDDocumentIDTypes#logicalID
 * status = #current
 * content.attachment.contentType = #text/plain
 * content.attachment.url = "http://example.com/nowhere.txt"
@@ -144,6 +147,11 @@ Usage: #example
 * content.attachment.size = 190
 * relatesTo.code = #appends
 * relatesTo.target = Reference(DocumentReference/ex-documentreference)
+* extension[repositoryUniqueId].valueIdentifier.id = "urn:oid:1.2.3.14.15.926"
+* extension[repositoryUniqueId].valueIdentifier.system = "urn:ietf:rfc:3986"
+* extension[version].valuePositiveInt = 42
+* extension[documentAvailability].valueCoding.code = #urn:ihe:iti:2010:DocumentAvailability:Online
+* extension[documentAvailability].valueCoding.system = "urn:ietf:rfc:3986"
 
 Instance:   ex-DocumentReferenceComprehensiveDelayedAssembly
 InstanceOf: IHE.MHD.Comprehensive.DocumentReference

--- a/input/fsh/identifier.fsh
+++ b/input/fsh/identifier.fsh
@@ -33,6 +33,28 @@ Description: "entryUUID Identifier holding a UUID"
 * value obeys mhd-startswithuuid
 * use = #official
 
+CodeSystem:  MHDDocumentIDTypes 
+Title: "MHD DocumentId Types"
+Description:  "Different types of document IDs"
+* ^caseSensitive = true
+* ^experimental = false
+* #entryUUID "DocumentEntry.entryUUID"
+* #logicalID "DocumentEntry.logicalID"
+* #uniqueID "DocumentEntry.uniqueID" 
+
+Profile: LogicalIDIdentifier
+Parent: Identifier
+Id: IHE.MHD.LogicalID.Identifier
+Title: "logicalID Identifier"
+Description: "logicalID Identifier holding a UUID"
+* system 1..
+* system = "urn:ietf:rfc:3986" (exactly)
+* value 1..
+* value obeys mhd-startswithuuid
+* use 0..0
+* type 1..1
+* type.coding = MHDDocumentIDTypes#logicalID
+
 Invariant: mhd-startswithuuid
 Description: "value must start with urn:uuid:"
 Severity: #error

--- a/input/fsh/identifier.fsh
+++ b/input/fsh/identifier.fsh
@@ -31,6 +31,7 @@ Description: "entryUUID Identifier holding a UUID"
 * system = "urn:ietf:rfc:3986" (exactly)
 * value 1..
 * value obeys mhd-startswithuuid
+* use 1..1
 * use = #official
 
 CodeSystem:  MHDDocumentIDTypes 


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 

Please make sure that the pull request is limited to one Issue and keep it as small as possible. You can open multiple pull request instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->
This PR introduces changes which enable a mapping between MHD DocumentReference resources and XDS Metadata Update requests.  The following XDS attributes are in focus:
* logicalID
* repositoryUniqueID
* version
* documentAvailability

The first one is mapped to a dedicated slice of `DocumentReference.identifier`, the latter three -- to extensions.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [X] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [X] All the tests have passed
- [x] I have selected a committee co-chair to review the PR

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->