### PR TITLE
Change mapping target from 'XDS' to the IHE URL

### DIFF
--- a/input/fsh/documentReference.fsh
+++ b/input/fsh/documentReference.fsh
@@ -115,7 +115,7 @@ Description:    "A profile on the DocumentReference resource for MHD Comprehensi
 // mappings to XDS 
 Mapping: DocumentEntry-Mapping
 Source:	MinimalDocumentReference
-Target: "XDS"
+Target: "https://www.ihe.net"
 Title: "XDS and MHD Mapping"
 * -> "XDS DocumentEntry: Used in the context of the IHE MHD ImplementationGuide"
 * category -> "DocumentEntry.classCode"

--- a/input/fsh/folder.fsh
+++ b/input/fsh/folder.fsh
@@ -55,7 +55,7 @@ Description:    "A profile on the List resource for MHD Comprehensive Metadata F
 //  mappings to XDS 
 Mapping: Folder-Mapping
 Source:	IHE.MHD.Minimal.Folder
-Target: "XDS"
+Target: "https://www.ihe.net"
 Title: "XDS and MHD Mapping"
 * -> "XDS Folder: Used in the context of the IHE MHD ImplementationGuide"
 * meta.profile -> "Folder.limitedMetadata"

--- a/input/fsh/submissionSet.fsh
+++ b/input/fsh/submissionSet.fsh
@@ -120,7 +120,7 @@ Description:    "A profile on the List resource for MHD Comprehensive Submission
 // mappings to XDS 
 Mapping: SubmissionSet-Mapping
 Source:	IHE.MHD.Minimal.SubmissionSet
-Target: "XDS"
+Target: "https://www.ihe.net"
 Title: "XDS and MHD Mapping"
 * -> "XDS SubmissionSet: Used in the context of the IHE MHD ImplementationGuide"
 * meta.profile -> "SubmissionSet.limitedMetadata"


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #244

## 📑 Description
The mapping target needs now to be resolvable by the IG Publisher (but always needed to be a URI). This PR updates the mapping target from 'XDS' to 'https://www.ihe.net'.

This should have no consequence for implementers.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed
- [ ] I have selected a committee co-chair to review the PR

## ℹ Additional Information
Any other URL could do it as well.