### PR TITLE
Use identifier.type to distinguish unqiueId and entryUUID.

### DIFF
--- a/input/fsh/Bundle-FindDocumentReferences.fsh
+++ b/input/fsh/Bundle-FindDocumentReferences.fsh
@@ -21,8 +21,6 @@ InstanceOf: IHE.MHD.Comprehensive.DocumentReference
 Usage: #inline
 * identifier[uniqueId].system = "urn:ietf:rfc:3986"
 * identifier[uniqueId].value = "urn:oid:1.3.6.1.4.1.12559.11.13.2.1.2951"
-* identifier[uniqueId].use = #usual
-* identifier[entryUUID].use = #official
 * identifier[entryUUID].system = "urn:ietf:rfc:3986"
 * identifier[entryUUID].value = "urn:uuid:50383ae5-49e5-4dea-b0e6-660cb9e7b91f"
 * status = #current

--- a/input/fsh/SimplifiedPublish.fsh
+++ b/input/fsh/SimplifiedPublish.fsh
@@ -21,14 +21,18 @@ Simplified Publish
   - Document Recipient is expected to extract the .data, use .url
 """
 * modifierExtension 0..0
-* identifier 1..1 MS
+* identifier 1..* 
 * identifier ^slicing.discriminator.type = #value
-* identifier ^slicing.discriminator.path = "use"
+* identifier ^slicing.discriminator.path = "type"
 * identifier ^slicing.rules = #open
-* identifier contains 
-    uniqueId 1..1 MS
-* identifier[uniqueId].use = #usual
+* identifier contains entryUUID 0..0
+* identifier[entryUUID] only EntryUUIDIdentifier
+* identifier[entryUUID] ^short = "Business identifier for the DocumentReference"
+* identifier[entryUUID]. ^definition = "The Business identifier for the DocumentReference which maps to the DocumentEntry.entryUUID in XDS. This is used to refer to the DocumentReference itself as a record of the Document's metadata, as opposed to the UniqueId element which identifies the document which is pointed at by the document reference. This element SHALL NOT be provided by the client for simplified publish and will instead be assigned by the server."
+* identifier contains uniqueId 1..1 MS
 * identifier[uniqueId] only UniqueIdIdentifier
+* identifier[uniqueId] ^short = "Unique identifier for the referenced Document"
+* identifier[uniqueId] ^definition = "The unique identifier for the referenced Document which maps to the DocumentEntry.uniqueId in XDS. This is used to identify the document which is pointed at by the DocumentReference Resource, as opposed to the entryUUID element which identifies the DocumentReference Resource itself."
 * status 1..1
 * status = http://hl7.org/fhir/document-reference-status#current
 * docStatus 0..0

--- a/input/fsh/documentReference.fsh
+++ b/input/fsh/documentReference.fsh
@@ -31,19 +31,18 @@ Description:    "A profile on the DocumentReference resource for MHD with minima
 - ebRIM implementation at [3:4.2.3.2 Document Entry](https://profiles.ihe.net/ITI/TF/Volume3/ch-4.2.html#4.2.3.2).
 - with use-cases and constraints found in [3:4.3 Additional Document Sharing Requirements](https://profiles.ihe.net/ITI/TF/Volume3/ch-4.3.html#4.3)"
 * modifierExtension 0..0
-//* identifier[uniqueId] only UniqueIdIdentifier
-//* identifier[uniqueId] 1..1
-* identifier 0..* MS
+* identifier 1..* MS
 * identifier ^slicing.discriminator.type = #value
-* identifier ^slicing.discriminator.path = "use"
+* identifier ^slicing.discriminator.path = "type"
 * identifier ^slicing.rules = #open
-* identifier contains 
-    uniqueId 1..1 MS and
-    entryUUID 0..* MS
-* identifier[uniqueId].use = #usual
-* identifier[uniqueId] only UniqueIdIdentifier
-* identifier[entryUUID].use = #official
+* identifier contains entryUUID 0..1 MS
 * identifier[entryUUID] only EntryUUIDIdentifier
+* identifier[entryUUID] ^short = "Business identifier for the DocumentReference"
+* identifier[entryUUID]. ^definition = "The Business identifier for the DocumentReference which maps to the DocumentEntry.entryUUID in XDS. This is used to refer to the DocumentReference itself as a record of the Document's metadata, as opposed to the UniqueId element which identifies the document which is pointed at by the document reference."
+* identifier contains uniqueId 1..1 MS
+* identifier[uniqueId] only UniqueIdIdentifier
+* identifier[uniqueId] ^short = "Unique identifier for the referenced Document"
+* identifier[uniqueId] ^definition = "The unique identifier for the referenced Document which maps to the DocumentEntry.uniqueId in XDS. This is used to identify the document which is pointed at by the DocumentReference Resource, as opposed to the entryUUID element which identifies the DocumentReference Resource itself."
 * status 1..1
 * status from DocumentReferenceStats (required)
 * docStatus 0..0
@@ -55,7 +54,6 @@ Description:    "A profile on the DocumentReference resource for MHD with minima
 * author 0..* MS
 * attester 0..1
 * attester.party 1..1
-//* custodian 0..0
 * description 0..1
 * securityLabel 0..* MS
 * content 1..1
@@ -142,8 +140,7 @@ Title: "XDS and MHD Mapping"
 * description -> "DocumentEntry.comments"
 * securityLabel -> "DocumentEntry.confidentialityCode"
 * content.attachment.creation -> "DocumentEntry.creationTime"
-* identifier[entryUUID] -> "DocumentEntry.entryUUID"
-* identifier[uniqueId] -> "DocumentEntry.uniqueId"
+* identifier -> "DocumentEntry.entryUUID and DocumentEntry.uniqueId"
 * event.concept -> "DocumentEntry.eventCodeList"
 * content.profile.valueCoding -> "DocumentEntry.formatCode"
 * content.attachment.hash -> "DocumentEntry.hash"

--- a/input/fsh/ex-DocumentReference.fsh
+++ b/input/fsh/ex-DocumentReference.fsh
@@ -8,7 +8,6 @@ Usage: #example
 * identifier[uniqueId].value = "urn:oid:1.2.840.113556.1.8000.2554.53432.348.12973.17740.34205.4355.50220.62012"
 * identifier[entryUUID].system = "urn:ietf:rfc:3986"
 * identifier[entryUUID].value = "urn:uuid:7d5bb8ac-68ee-4926-85e7-b8aac8e1f09d"
-* identifier[entryUUID].use = #official
 * status = #current
 * content.attachment.contentType = #text/plain
 * content.attachment.url = "http://example.com/nowhere.txt"
@@ -23,7 +22,6 @@ Usage: #example
 * identifier[uniqueId].value = "urn:oid:1.2.840.113556.1.8000.2554.53432.348.12973.17740.34205.4355.50220.62012"
 * identifier[entryUUID].system = "urn:ietf:rfc:3986"
 * identifier[entryUUID].value = "urn:uuid:7d5bb8ac-68ee-4926-85e7-b8aac8e1f09d"
-* identifier[entryUUID].use = #official
 * status = #current
 * content.attachment.contentType = #text/plain
 * content.attachment.url = "http://example.com/nowhere.txt"
@@ -40,7 +38,6 @@ Usage: #example
 * identifier[uniqueId].value = "urn:oid:1.2.840.113556.1.8000.2554.58783.21864.3474.19410.44358.58254.41281.46340"
 * identifier[entryUUID].system = "urn:ietf:rfc:3986"
 * identifier[entryUUID].value = "urn:uuid:0c287d32-01e3-4d87-9953-9fcc9404eb21"
-* identifier[entryUUID].use = #official
 * status = #current
 * content.attachment.contentType = #text/plain
 * content.attachment.url = "http://example.com/nowhere.txt"
@@ -67,7 +64,6 @@ Usage: #example
 * identifier[uniqueId].value = "urn:oid:1.2.840.113556.1.8000.2554.58783.21864.3474.19410.44358.58254.41281.46340"
 * identifier[entryUUID].system = "urn:ietf:rfc:3986"
 * identifier[entryUUID].value = "urn:uuid:0c287d32-01e3-4d87-9953-9fcc9404eb21"
-* identifier[entryUUID].use = #official
 * status = #current
 * content.attachment.contentType = #text/plain
 * content.attachment.url = "http://example.com/nowhere.txt"
@@ -112,7 +108,6 @@ Usage: #example
 * identifier[uniqueId].value = "urn:oid:1.2.840.113556.1.8000.2554.58783.21864.3474.19410.44358.58254.41281.46340"
 * identifier[entryUUID].system = "urn:ietf:rfc:3986"
 * identifier[entryUUID].value = "urn:uuid:0c287d32-01e3-4d87-9953-9fcc9404eb21"
-* identifier[entryUUID].use = #official
 * status = #current
 * content.attachment.contentType = #text/plain
 * content.attachment.url = "http://example.com/nowhere.txt"
@@ -165,7 +160,6 @@ Usage: #example
 * identifier[uniqueId].value = "urn:oid:1.2.840.113556.1.8000.2554.58783.21864.3474.19410.44358.58254.41281.47340"
 * identifier[entryUUID].system = "urn:ietf:rfc:3986"
 * identifier[entryUUID].value = "urn:uuid:0c287d32-01e3-4d87-9953-9fcc9407eb21"
-* identifier[entryUUID].use = #official
 * status = #current
 * content.attachment.contentType = #text/plain
 // This URL would be used to retrieve the content, and in this case that is when the content would be created
@@ -218,7 +212,6 @@ Usage: #example
 * identifier[uniqueId].value = "urn:oid:1.2.840.113556.1.8000.2554.58783.21864.3474.19410.44358.58254.41281.57340"
 * identifier[entryUUID].system = "urn:ietf:rfc:3986"
 * identifier[entryUUID].value = "urn:uuid:0c287d32-01e3-4d87-9953-9fc59407eb21"
-* identifier[entryUUID].use = #official
 * status = #current
 * content.attachment.contentType = #text/plain
 // This URL would be used to retrieve the content, and in this case that is when the content would be created
@@ -251,7 +244,6 @@ Usage: #example
 * identifier[uniqueId].value = "urn:oid:1.2.840.113556.1.8000.2554.58783.21864.3474.19410.44358.58254.41381.57340"
 * identifier[entryUUID].system = "urn:ietf:rfc:3986"
 * identifier[entryUUID].value = "urn:uuid:0c287d32-01e3-4d87-9953-91c59407eb21"
-* identifier[entryUUID].use = #official
 * status = #current
 * content.attachment.contentType = #text/plain
 * type = http://loinc.org#60591-5
@@ -324,7 +316,6 @@ Usage: #inline
 * identifier[uniqueId].value = "urn:oid:1.2.840.113556.1.8000.2554.53432.348.12973.17740.34205.4355.50220.62012"
 * identifier[entryUUID].system = "urn:ietf:rfc:3986"
 * identifier[entryUUID].value = "urn:uuid:7d5bb8ac-68ee-4926-85e7-b8aac8e1f09d"
-* identifier[entryUUID].use = #official
 * status = #current
 * content.attachment.contentType = #text/plain
 * content.attachment.url = "http://example.com/nowhere.txt"

--- a/input/fsh/ex-SubmissionSet.fsh
+++ b/input/fsh/ex-SubmissionSet.fsh
@@ -6,7 +6,7 @@ Usage: #example
 * meta.security = http://terminology.hl7.org/CodeSystem/v3-ActReason#HTEST
 * identifier[entryUUID].system = "urn:ietf:rfc:3986"
 * identifier[entryUUID].value = "urn:uuid:40b3366f-7e4b-4d02-bbac-901aaa8d7183"
-* identifier[entryUUID].use = #official
+* identifier[entryUUID].type = MHDIdentifierType#entryUUID
 * identifier[uniqueId].system = "urn:ietf:rfc:3986"
 * identifier[uniqueId].value = "urn:oid:1.2.840.113556.1.8000.2554.58783.21864.3474.19410.44358.58254.41281.46354"
 * identifier[uniqueId].use = #usual
@@ -27,7 +27,7 @@ Usage: #example
 * subject = Reference(Patient/ex-patient)
 * identifier[entryUUID].system = "urn:ietf:rfc:3986"
 * identifier[entryUUID].value = "urn:uuid:340d303b-b889-4d44-b766-27f14c212236"
-* identifier[entryUUID].use = #official
+* identifier[entryUUID].type = MHDIdentifierType#entryUUID
 * identifier[uniqueId].system = "urn:ietf:rfc:3986"
 * identifier[uniqueId].value = "urn:oid:1.2.840.113556.1.8000.2554.58783.21864.3474.19410.44358.58254.41281.46355"
 * identifier[uniqueId].use = #usual

--- a/input/fsh/folder.fsh
+++ b/input/fsh/folder.fsh
@@ -11,13 +11,16 @@ Description:    "A profile on the List resource for MHD use as a Folder with min
 - with use-cases and constraints found in [3:4.3 Additional Document Sharing Requirements](https://profiles.ihe.net/ITI/TF/Volume3/ch-4.3.html#4.3)"
 * extension[designationType] 0..* MS
 * identifier ^slicing.discriminator.type = #value
-* identifier ^slicing.discriminator.path = "use"
+* identifier ^slicing.discriminator.path = "type"
 * identifier ^slicing.rules = #open
 * identifier contains uniqueId 0..1 MS
 * identifier[uniqueId] only UniqueIdIdentifier
-* identifier contains entryUUID 0..* MS
+* identifier[uniqueId] ^short = "Folder.uniqueId"
+* identifier[uniqueId] ^definition = "The XDS UniqueId for the Folder. Globally unique identifier for the Folder."
+* identifier contains entryUUID 0..1 MS
 * identifier[entryUUID] only EntryUUIDIdentifier
-//* status 
+* identifier[entryUUID] ^short = "Folder.entryUUID"
+* identifier[entryUUID] ^definition = "The XDS entryUUID for the Folder. A globally unique identifier used to identify the XDS Folder entry in ebRIM."
 * mode = #working
 * title 0..1
 * code = MHDlistTypes#folder

--- a/input/fsh/identifier.fsh
+++ b/input/fsh/identifier.fsh
@@ -6,9 +6,9 @@ Description: "uniqueId Identifier
 
 - see [Appendix Z](https://profiles.ihe.net/ITI/TF/Volume2/ch-Z.html#z.9.1-identifier-type)"
 * system 1..
-* use 1..
-* use = #usual
 * value 1..
+* type 1..1
+* type = MHDIdentifierType#uniqueId
 
 Profile: SubmissionSetUniqueIdIdentifier
 Parent: UniqueIdIdentifier
@@ -32,10 +32,27 @@ Description: "entryUUID Identifier holding a UUID"
 * system = "urn:ietf:rfc:3986" //(exactly)
 * value 1..
 * value obeys mhd-startswithuuid
-* use 1..
-* use = #official
+* type 1..1
+* type = MHDIdentifierType#entryUUID
 
 Invariant: mhd-startswithuuid
 Description: "value must start with urn:uuid:"
 Severity: #error
 Expression: "startsWith('urn:uuid:')"
+
+CodeSystem: MHDIdentifierType
+Id: IHE.MHD.MHDIdentifierType
+Title: "IHE MHD Identifier Types"
+Description: "Code System for Identifier.type values defined in IHE MHD"
+* ^caseSensitive = true
+* ^experimental = false
+* #entryUUID "Identifier type for XDS entryUUID"
+* #uniqueId "Identifier type for XDS UniqueId"
+
+ValueSet: MHDIdentifierTypeVS
+Id: IHE.MHD.MHDIdentifierTypeVS
+Title: "IHE MHD Identifier Types ValueSet"
+Description: "ValueSet for Identifier.type values defined in IHE MHD"
+* ^experimental = false
+* MHDIdentifierType#entryUUID
+* MHDIdentifierType#uniqueId

--- a/input/fsh/provide-bundle-with-fhir-document.fsh
+++ b/input/fsh/provide-bundle-with-fhir-document.fsh
@@ -56,10 +56,8 @@ Usage: #inline
 * meta.security = $v3-ActReason#HTEST
 * identifier[uniqueId].system = "urn:ietf:rfc:3986"
 * identifier[uniqueId].value = "urn:uuid:0c3151bd-1cbf-4d64-b04d-cd9187a4c6e0"
-* identifier[uniqueId].use = #usual
 * identifier[entryUUID].system = "urn:ietf:rfc:3986"
 * identifier[entryUUID].value = "urn:uuid:7d5bb8ac-68ee-4926-85e7-b8aac8e1f09d"
-* identifier[entryUUID].use = #official
 * status = #current
 * type = $loinc#28655-9
 * category = $loinc#11369-6

--- a/input/fsh/submissionSet.fsh
+++ b/input/fsh/submissionSet.fsh
@@ -17,12 +17,16 @@ Description:    "A profile on the List resource for MHD SubmissionSet.
 * extension contains SourceId named sourceId 1..1
 * extension contains IntendedRecipient named intendedRecipient 0..*
 * identifier ^slicing.discriminator.type = #value
-* identifier ^slicing.discriminator.path = "use"
+* identifier ^slicing.discriminator.path = "type"
 * identifier ^slicing.rules = #open
-* identifier contains uniqueId 0..1 MS
+* identifier contains uniqueId 0..1 MS 
 * identifier[uniqueId] only SubmissionSetUniqueIdIdentifier
-* identifier contains entryUUID 0..* MS
+* identifier[uniqueId] ^short = "SubmissionSet.uniqueId"
+* identifier[uniqueId] ^definition = "The XDS UniqueId for the SubmissionSet. Globally unique identifier for the SubmissionSet assigned by the creating entity."
+* identifier contains entryUUID 0..1 MS
 * identifier[entryUUID] only EntryUUIDIdentifier
+* identifier[entryUUID] ^short = "SubmissionSet.entryUUID"
+* identifier[entryUUID] ^definition = "The XDS entryUUID for the SubmissionSet. A globally unique identifier used to identify the XDS SubmissionSet in ebRIM."
 * status = #current
 * mode = #working
 * title 0..1


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 

Please make sure that the pull request is limited to one Issue and keep it as small as possible. You can open multiple pull request instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #255

## 📑 Description
<!-- Add a brief description of the pr -->

This PR updates the MHD R5 profiles to use identifier.type rather than identifier.use to differentiate the values tracked for XDS EntryUUID and UniqueId.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [X] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed
- [ ] I have selected a committee co-chair to review the PR

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->